### PR TITLE
Bugfix for validator bond updating

### DIFF
--- a/tests/integration/staking/keeper/msg_server_test.go
+++ b/tests/integration/staking/keeper/msg_server_test.go
@@ -1127,6 +1127,163 @@ func TestValidatorBond(t *testing.T) {
 	}
 }
 
+func TestChangeValidatorBond(t *testing.T) {
+	_, app, ctx := createTestInput(t)
+	msgServer := keeper.NewMsgServerImpl(app.StakingKeeper)
+
+	checkValidatorBondShares := func(validatorAddress sdk.ValAddress, expectedShares sdk.Int) {
+		validator, found := app.StakingKeeper.GetValidator(ctx, validatorAddress)
+		require.True(t, found, "validator should have been found")
+		require.Equal(t, expectedShares.Int64(), validator.ValidatorBondShares.TruncateInt64(), "validator bond shares")
+	}
+
+	// Create a delegator and 3 validators
+	addresses := simtestutil.AddTestAddrs(app.BankKeeper, app.StakingKeeper, ctx, 4, sdk.NewInt(1_000_000))
+	pubKeys := simtestutil.CreateTestPubKeys(4)
+
+	validatorAPubKey := pubKeys[1]
+	validatorBPubKey := pubKeys[2]
+	validatorCPubKey := pubKeys[3]
+
+	delegatorAddress := addresses[0]
+	validatorAAddress := sdk.ValAddress(validatorAPubKey.Address())
+	validatorBAddress := sdk.ValAddress(validatorBPubKey.Address())
+	validatorCAddress := sdk.ValAddress(validatorCPubKey.Address())
+
+	validatorA := stakingtestutil.NewValidator(t, validatorAAddress, validatorAPubKey)
+	validatorB := stakingtestutil.NewValidator(t, validatorBAddress, validatorBPubKey)
+	validatorC := stakingtestutil.NewValidator(t, validatorCAddress, validatorCPubKey)
+
+	validatorA.Tokens = sdk.NewInt(1_000_000)
+	validatorB.Tokens = sdk.NewInt(1_000_000)
+	validatorC.Tokens = sdk.NewInt(1_000_000)
+	validatorA.DelegatorShares = sdk.NewDec(1_000_000)
+	validatorB.DelegatorShares = sdk.NewDec(1_000_000)
+	validatorC.DelegatorShares = sdk.NewDec(1_000_000)
+
+	app.StakingKeeper.SetValidator(ctx, validatorA)
+	app.StakingKeeper.SetValidator(ctx, validatorB)
+	app.StakingKeeper.SetValidator(ctx, validatorC)
+
+	// The test will go through Delegate/Redelegate/Undelegate messages with the following
+	delegation1Amount := sdk.NewInt(1000)
+	delegation2Amount := sdk.NewInt(1000)
+	redelegateAmount := sdk.NewInt(500)
+	undelegateAmount := sdk.NewInt(500)
+
+	delegate1Coin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delegation1Amount)
+	delegate2Coin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delegation2Amount)
+	redelegateCoin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), redelegateAmount)
+	undelegateCoin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), undelegateAmount)
+
+	// Delegate to validator's A and C - validator bond shares should not change
+	_, err := msgServer.Delegate(sdk.WrapSDKContext(ctx), &types.MsgDelegate{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+		Amount:           delegate1Coin,
+	})
+	require.NoError(t, err, "no error expected during first delegation")
+
+	_, err = msgServer.Delegate(sdk.WrapSDKContext(ctx), &types.MsgDelegate{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorCAddress.String(),
+		Amount:           delegate1Coin,
+	})
+	require.NoError(t, err, "no error expected during first delegation")
+
+	checkValidatorBondShares(validatorAAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorCAddress, sdk.ZeroInt())
+
+	// Flag the the delegations to validator A and C validator bond's
+	// Their bond shares should increase
+	_, err = msgServer.ValidatorBond(sdk.WrapSDKContext(ctx), &types.MsgValidatorBond{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+	})
+	require.NoError(t, err, "no error expected during validator bond")
+
+	_, err = msgServer.ValidatorBond(sdk.WrapSDKContext(ctx), &types.MsgValidatorBond{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorCAddress.String(),
+	})
+	require.NoError(t, err, "no error expected during validator bond")
+
+	checkValidatorBondShares(validatorAAddress, delegation1Amount)
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorCAddress, delegation1Amount)
+
+	// Delegate more to validator A - it should increase the validator bond shares
+	_, err = msgServer.Delegate(sdk.WrapSDKContext(ctx), &types.MsgDelegate{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+		Amount:           delegate2Coin,
+	})
+	require.NoError(t, err, "no error expected during second delegation")
+
+	checkValidatorBondShares(validatorAAddress, delegation1Amount.Add(delegation2Amount))
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorCAddress, delegation1Amount)
+
+	// Redelegate partially from A to B (where A is a validator bond and B is not)
+	// It should remove the bond shares from A, and B's validator bond shares should not change
+	_, err = msgServer.BeginRedelegate(sdk.WrapSDKContext(ctx), &types.MsgBeginRedelegate{
+		DelegatorAddress:    delegatorAddress.String(),
+		ValidatorSrcAddress: validatorAAddress.String(),
+		ValidatorDstAddress: validatorBAddress.String(),
+		Amount:              redelegateCoin,
+	})
+	require.NoError(t, err, "no error expected during redelegation")
+
+	expectedBondSharesA := delegation1Amount.Add(delegation2Amount).Sub(redelegateAmount)
+	checkValidatorBondShares(validatorAAddress, expectedBondSharesA)
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorCAddress, delegation1Amount)
+
+	// Now redelegate from B to C (where B is not a validator bond, but C is)
+	// Validator B's bond shares should remain at zero, but C's bond shares should increase
+	_, err = msgServer.BeginRedelegate(sdk.WrapSDKContext(ctx), &types.MsgBeginRedelegate{
+		DelegatorAddress:    delegatorAddress.String(),
+		ValidatorSrcAddress: validatorBAddress.String(),
+		ValidatorDstAddress: validatorCAddress.String(),
+		Amount:              redelegateCoin,
+	})
+	require.NoError(t, err, "no error expected during redelegation")
+
+	checkValidatorBondShares(validatorAAddress, expectedBondSharesA)
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorCAddress, delegation1Amount.Add(redelegateAmount))
+
+	// Redelegate partially from A to C (where C is a validator bond delegation)
+	// It should remove the bond shares from A, and increase the bond shares on validator C
+	_, err = msgServer.BeginRedelegate(sdk.WrapSDKContext(ctx), &types.MsgBeginRedelegate{
+		DelegatorAddress:    delegatorAddress.String(),
+		ValidatorSrcAddress: validatorAAddress.String(),
+		ValidatorDstAddress: validatorCAddress.String(),
+		Amount:              redelegateCoin,
+	})
+	require.NoError(t, err, "no error expected during redelegation")
+
+	expectedBondSharesA = expectedBondSharesA.Sub(redelegateAmount)
+	expectedBondSharesC := delegation1Amount.Add(redelegateAmount).Add(redelegateAmount)
+	checkValidatorBondShares(validatorAAddress, expectedBondSharesA)
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorCAddress, expectedBondSharesC)
+
+	// Undelegate from validator A - it should remove shares
+	_, err = msgServer.Undelegate(sdk.WrapSDKContext(ctx), &types.MsgUndelegate{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+		Amount:           undelegateCoin,
+	})
+	require.NoError(t, err, "no error expected during undelegation")
+
+	expectedBondSharesA = expectedBondSharesA.Sub(undelegateAmount)
+	checkValidatorBondShares(validatorAAddress, expectedBondSharesA)
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorCAddress, expectedBondSharesC)
+}
+
 func TestEnableDisableTokenizeShares(t *testing.T) {
 	_, app, ctx := createTestInput(t)
 	msgServer := keeper.NewMsgServerImpl(app.StakingKeeper)
@@ -1283,79 +1440,6 @@ func TestUnbondValidator(t *testing.T) {
 	require.True(t, validator.Jailed)
 }
 
-// TestICADelegateUndelegate tests that an ICA account can undelegate
-// sequentially right after delegating.
-func TestICADelegateUndelegate(t *testing.T) {
-	_, app, ctx := createTestInput(t)
-	msgServer := keeper.NewMsgServerImpl(app.StakingKeeper)
-
-	// Create a delegator and validator (the delegator will be an ICA account)
-	delegateAmount := sdk.NewInt(1000)
-	delegateCoin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delegateAmount)
-	icaAccountAddress := createICAAccount(app, ctx)
-
-	// Fund ICA account
-	err := app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(delegateCoin))
-	require.NoError(t, err)
-	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, icaAccountAddress, sdk.NewCoins(delegateCoin))
-	require.NoError(t, err)
-
-	addresses := simtestutil.AddTestAddrs(app.BankKeeper, app.StakingKeeper, ctx, 1, sdk.NewInt(0))
-	pubKeys := simtestutil.CreateTestPubKeys(1)
-	validatorAddress := sdk.ValAddress(addresses[0])
-	validator := stakingtestutil.NewValidator(t, validatorAddress, pubKeys[0])
-
-	validator.DelegatorShares = sdk.NewDec(1_000_000)
-	validator.Tokens = sdk.NewInt(1_000_000)
-	validator.LiquidShares = sdk.NewDec(0)
-	app.StakingKeeper.SetValidator(ctx, validator)
-
-	delegateMsg := types.MsgDelegate{
-		DelegatorAddress: icaAccountAddress.String(),
-		ValidatorAddress: validatorAddress.String(),
-		Amount:           delegateCoin,
-	}
-
-	undelegateMsg := types.MsgUndelegate{
-		DelegatorAddress: icaAccountAddress.String(),
-		ValidatorAddress: validatorAddress.String(),
-		Amount:           delegateCoin,
-	}
-
-	// Delegate normally
-	_, err = msgServer.Delegate(sdk.WrapSDKContext(ctx), &delegateMsg)
-	require.NoError(t, err, "no error expected when delegating")
-
-	// Confirm delegation record
-	_, found := app.StakingKeeper.GetDelegation(ctx, icaAccountAddress, validatorAddress)
-	require.True(t, found, "delegation should have been found")
-
-	// Confirm liquid staking totals were incremented
-	expectedTotalLiquidStaked := delegateAmount.Int64()
-	actualTotalLiquidStaked := app.StakingKeeper.GetTotalLiquidStakedTokens(ctx).Int64()
-	require.Equal(t, expectedTotalLiquidStaked, actualTotalLiquidStaked, "total liquid staked tokens after delegation")
-
-	validator, found = app.StakingKeeper.GetValidator(ctx, validatorAddress)
-	require.True(t, found, "validator should have been found")
-	require.Equal(t, sdk.NewDecFromInt(delegateAmount), validator.LiquidShares, "validator liquid shares after delegation")
-
-	// Try to undelegate
-	_, err = msgServer.Undelegate(sdk.WrapSDKContext(ctx), &undelegateMsg)
-	require.NoError(t, err, "no error expected when sequentially undelegating")
-
-	// Confirm delegation record was removed
-	_, found = app.StakingKeeper.GetDelegation(ctx, icaAccountAddress, validatorAddress)
-	require.False(t, found, "delegation not have been found")
-
-	// Confirm liquid staking totals were decremented
-	actualTotalLiquidStaked = app.StakingKeeper.GetTotalLiquidStakedTokens(ctx).Int64()
-	require.Zero(t, actualTotalLiquidStaked, "total liquid staked tokens after undelegation")
-
-	validator, found = app.StakingKeeper.GetValidator(ctx, validatorAddress)
-	require.True(t, found, "validator should have been found")
-	require.Equal(t, sdk.ZeroDec(), validator.LiquidShares, "validator liquid shares after undelegation")
-}
-
 func TestChangeValidatorBond(t *testing.T) {
 	_, app, ctx := createTestInput(t)
 	msgServer := keeper.NewMsgServerImpl(app.StakingKeeper)
@@ -1454,4 +1538,205 @@ func TestChangeValidatorBond(t *testing.T) {
 	expectedBondShares := delegation1Amount.Add(delegation2Amount).Sub(redelegateAmount).Sub(undelegateAmount)
 	checkValidatorBondShares(validatorAAddress, expectedBondShares)
 	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+}
+
+// TestICADelegateUndelegate tests that an ICA account can undelegate
+// sequentially right after delegating.
+func TestICADelegateUndelegate(t *testing.T) {
+	_, app, ctx := createTestInput(t)
+	msgServer := keeper.NewMsgServerImpl(app.StakingKeeper)
+
+	// Create a delegator and validator (the delegator will be an ICA account)
+	delegateAmount := sdk.NewInt(1000)
+	delegateCoin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delegateAmount)
+	icaAccountAddress := createICAAccount(app, ctx)
+
+	// Fund ICA account
+	err := app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(delegateCoin))
+	require.NoError(t, err)
+	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, icaAccountAddress, sdk.NewCoins(delegateCoin))
+	require.NoError(t, err)
+
+	addresses := simtestutil.AddTestAddrs(app.BankKeeper, app.StakingKeeper, ctx, 1, sdk.NewInt(0))
+	pubKeys := simtestutil.CreateTestPubKeys(1)
+	validatorAddress := sdk.ValAddress(addresses[0])
+	validator := stakingtestutil.NewValidator(t, validatorAddress, pubKeys[0])
+
+	validator.DelegatorShares = sdk.NewDec(1_000_000)
+	validator.Tokens = sdk.NewInt(1_000_000)
+	validator.LiquidShares = sdk.NewDec(0)
+	app.StakingKeeper.SetValidator(ctx, validator)
+
+	delegateMsg := types.MsgDelegate{
+		DelegatorAddress: icaAccountAddress.String(),
+		ValidatorAddress: validatorAddress.String(),
+		Amount:           delegateCoin,
+	}
+
+	undelegateMsg := types.MsgUndelegate{
+		DelegatorAddress: icaAccountAddress.String(),
+		ValidatorAddress: validatorAddress.String(),
+		Amount:           delegateCoin,
+	}
+
+	// Delegate normally
+	_, err = msgServer.Delegate(sdk.WrapSDKContext(ctx), &delegateMsg)
+	require.NoError(t, err, "no error expected when delegating")
+
+	// Confirm delegation record
+	_, found := app.StakingKeeper.GetDelegation(ctx, icaAccountAddress, validatorAddress)
+	require.True(t, found, "delegation should have been found")
+
+	// Confirm liquid staking totals were incremented
+	expectedTotalLiquidStaked := delegateAmount.Int64()
+	actualTotalLiquidStaked := app.StakingKeeper.GetTotalLiquidStakedTokens(ctx).Int64()
+	require.Equal(t, expectedTotalLiquidStaked, actualTotalLiquidStaked, "total liquid staked tokens after delegation")
+
+	validator, found = app.StakingKeeper.GetValidator(ctx, validatorAddress)
+	require.True(t, found, "validator should have been found")
+	require.Equal(t, sdk.NewDecFromInt(delegateAmount), validator.LiquidShares, "validator liquid shares after delegation")
+
+	// Try to undelegate
+	_, err = msgServer.Undelegate(sdk.WrapSDKContext(ctx), &undelegateMsg)
+	require.NoError(t, err, "no error expected when sequentially undelegating")
+
+	// Confirm delegation record was removed
+	_, found = app.StakingKeeper.GetDelegation(ctx, icaAccountAddress, validatorAddress)
+	require.False(t, found, "delegation not have been found")
+
+	// Confirm liquid staking totals were decremented
+	actualTotalLiquidStaked = app.StakingKeeper.GetTotalLiquidStakedTokens(ctx).Int64()
+	require.Zero(t, actualTotalLiquidStaked, "total liquid staked tokens after undelegation")
+
+	validator, found = app.StakingKeeper.GetValidator(ctx, validatorAddress)
+	require.True(t, found, "validator should have been found")
+	require.Equal(t, sdk.ZeroDec(), validator.LiquidShares, "validator liquid shares after undelegation")
+}
+
+func TestCancelUnbondingDelegation(t *testing.T) {
+	_, app, ctx := createTestInput(t)
+	msgServer := keeper.NewMsgServerImpl(app.StakingKeeper)
+
+	bondDenom := app.StakingKeeper.BondDenom(ctx)
+
+	// set the not bonded pool module account
+	notBondedPool := app.StakingKeeper.GetNotBondedPool(ctx)
+	startTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 5)
+	startCoin := sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), startTokens))
+
+	require.NoError(t, testutil.FundModuleAccount(app.BankKeeper, ctx, notBondedPool.GetName(), startCoin))
+	app.AccountKeeper.SetModuleAccount(ctx, notBondedPool)
+
+	moduleBalance := app.BankKeeper.GetBalance(ctx, notBondedPool.GetAddress(), app.StakingKeeper.BondDenom(ctx))
+	require.Equal(t, sdk.NewInt64Coin(bondDenom, startTokens.Int64()), moduleBalance)
+
+	// create a  validator
+	validatorPubKey := simtestutil.CreateTestPubKeys(1)[0]
+	validatorAddr := sdk.ValAddress(validatorPubKey.Address())
+
+	validator := stakingtestutil.NewValidator(t, validatorAddr, validatorPubKey)
+	validator.Tokens = startTokens
+	validator.DelegatorShares = sdk.NewDecFromInt(startTokens)
+	validator.Status = types.Bonded
+	app.StakingKeeper.SetValidator(ctx, validator)
+
+	// create a delegator
+	delAddrs := simtestutil.AddTestAddrsIncremental(app.BankKeeper, app.StakingKeeper, ctx, 2, sdk.NewInt(10000))
+	delegatorAddr := delAddrs[0]
+
+	// setting the ubd entry
+	unbondingAmount := sdk.NewInt64Coin(app.StakingKeeper.BondDenom(ctx), 5)
+	ubd := types.NewUnbondingDelegation(
+		delegatorAddr, validatorAddr, 10,
+		ctx.BlockTime().Add(time.Minute*10),
+		unbondingAmount.Amount,
+		1,
+	)
+
+	// set and retrieve a record
+	app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
+	resUnbond, found := app.StakingKeeper.GetUnbondingDelegation(ctx, delegatorAddr, validatorAddr)
+	require.True(t, found)
+	require.Equal(t, ubd, resUnbond)
+
+	testCases := []struct {
+		Name      string
+		ExceptErr bool
+		req       types.MsgCancelUnbondingDelegation
+	}{
+		{
+			Name:      "invalid height",
+			ExceptErr: true,
+			req: types.MsgCancelUnbondingDelegation{
+				DelegatorAddress: resUnbond.DelegatorAddress,
+				ValidatorAddress: resUnbond.ValidatorAddress,
+				Amount:           sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(4)),
+				CreationHeight:   0,
+			},
+		},
+		{
+			Name:      "validator not exists",
+			ExceptErr: true,
+			req: types.MsgCancelUnbondingDelegation{
+				DelegatorAddress: resUnbond.DelegatorAddress,
+				ValidatorAddress: sdk.ValAddress(sdk.AccAddress("asdsad")).String(),
+				Amount:           unbondingAmount,
+				CreationHeight:   0,
+			},
+		},
+		{
+			Name:      "invalid delegator address",
+			ExceptErr: true,
+			req: types.MsgCancelUnbondingDelegation{
+				DelegatorAddress: "invalid_delegator_addrtess",
+				ValidatorAddress: resUnbond.ValidatorAddress,
+				Amount:           unbondingAmount,
+				CreationHeight:   0,
+			},
+		},
+		{
+			Name:      "invalid amount",
+			ExceptErr: true,
+			req: types.MsgCancelUnbondingDelegation{
+				DelegatorAddress: resUnbond.DelegatorAddress,
+				ValidatorAddress: resUnbond.ValidatorAddress,
+				Amount:           unbondingAmount.Add(sdk.NewInt64Coin(bondDenom, 10)),
+				CreationHeight:   10,
+			},
+		},
+		{
+			Name:      "success",
+			ExceptErr: false,
+			req: types.MsgCancelUnbondingDelegation{
+				DelegatorAddress: resUnbond.DelegatorAddress,
+				ValidatorAddress: resUnbond.ValidatorAddress,
+				Amount:           unbondingAmount.Sub(sdk.NewInt64Coin(bondDenom, 1)),
+				CreationHeight:   10,
+			},
+		},
+		{
+			Name:      "success",
+			ExceptErr: false,
+			req: types.MsgCancelUnbondingDelegation{
+				DelegatorAddress: resUnbond.DelegatorAddress,
+				ValidatorAddress: resUnbond.ValidatorAddress,
+				Amount:           unbondingAmount.Sub(unbondingAmount.Sub(sdk.NewInt64Coin(bondDenom, 1))),
+				CreationHeight:   10,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			_, err := msgServer.CancelUnbondingDelegation(sdk.WrapSDKContext(ctx), &testCase.req)
+			if testCase.ExceptErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				balanceForNotBondedPool := app.BankKeeper.GetBalance(ctx, sdk.AccAddress(notBondedPool.GetAddress()), bondDenom)
+				require.Equal(t, balanceForNotBondedPool, moduleBalance.Sub(testCase.req.Amount))
+				moduleBalance = moduleBalance.Sub(testCase.req.Amount)
+			}
+		})
+	}
 }

--- a/tests/integration/staking/keeper/msg_server_test.go
+++ b/tests/integration/staking/keeper/msg_server_test.go
@@ -1355,3 +1355,103 @@ func TestICADelegateUndelegate(t *testing.T) {
 	require.True(t, found, "validator should have been found")
 	require.Equal(t, sdk.ZeroDec(), validator.LiquidShares, "validator liquid shares after undelegation")
 }
+
+func TestChangeValidatorBond(t *testing.T) {
+	_, app, ctx := createTestInput(t)
+	msgServer := keeper.NewMsgServerImpl(app.StakingKeeper)
+
+	checkValidatorBondShares := func(validatorAddress sdk.ValAddress, expectedShares sdk.Int) {
+		validator, found := app.StakingKeeper.GetValidator(ctx, validatorAddress)
+		require.True(t, found, "validator should have been found")
+		require.Equal(t, expectedShares.Int64(), validator.ValidatorBondShares.TruncateInt64(), "validator bond shares")
+	}
+
+	// Create a delegator and 2 validators
+	addresses := simtestutil.AddTestAddrs(app.BankKeeper, app.StakingKeeper, ctx, 3, sdk.NewInt(1_000_000))
+	pubKeys := simtestutil.CreateTestPubKeys(3)
+
+	validatorAPubKey := pubKeys[1]
+	validatorBPubKey := pubKeys[2]
+
+	delegatorAddress := addresses[0]
+	validatorAAddress := sdk.ValAddress(validatorAPubKey.Address())
+	validatorBAddress := sdk.ValAddress(validatorBPubKey.Address())
+
+	validatorA := stakingtestutil.NewValidator(t, validatorAAddress, validatorAPubKey)
+	validatorB := stakingtestutil.NewValidator(t, validatorBAddress, validatorBPubKey)
+
+	validatorA.Tokens = sdk.NewInt(1_000_000)
+	validatorB.Tokens = sdk.NewInt(1_000_000)
+	validatorA.DelegatorShares = sdk.NewDec(1_000_000)
+	validatorB.DelegatorShares = sdk.NewDec(1_000_000)
+
+	app.StakingKeeper.SetValidator(ctx, validatorA)
+	app.StakingKeeper.SetValidator(ctx, validatorB)
+
+	// The test will go through Delegate/Redelegate/Undelegate messages with the following
+	delegation1Amount := sdk.NewInt(1000)
+	delegation2Amount := sdk.NewInt(1000)
+	redelegateAmount := sdk.NewInt(500)
+	undelegateAmount := sdk.NewInt(500)
+
+	delegate1Coin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delegation1Amount)
+	delegate2Coin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), delegation2Amount)
+	redelegateCoin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), redelegateAmount)
+	undelegateCoin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), undelegateAmount)
+
+	// Delegate to validator A - validator bond shares should not change
+	_, err := msgServer.Delegate(sdk.WrapSDKContext(ctx), &types.MsgDelegate{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+		Amount:           delegate1Coin,
+	})
+	require.NoError(t, err, "no error expected during first delegation")
+
+	checkValidatorBondShares(validatorAAddress, sdk.ZeroInt())
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+
+	// Flag the delegation as a validator bond
+	_, err = msgServer.ValidatorBond(sdk.WrapSDKContext(ctx), &types.MsgValidatorBond{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+	})
+	require.NoError(t, err, "no error expected during validator bond")
+
+	checkValidatorBondShares(validatorAAddress, delegation1Amount)
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+
+	// Delegate more - it should increase the validator bond shares
+	_, err = msgServer.Delegate(sdk.WrapSDKContext(ctx), &types.MsgDelegate{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+		Amount:           delegate2Coin,
+	})
+	require.NoError(t, err, "no error expected during second delegation")
+
+	checkValidatorBondShares(validatorAAddress, delegation1Amount.Add(delegation2Amount))
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+
+	// Redelegate partially from A to B - it should remove the bond shares from the source validator
+	_, err = msgServer.BeginRedelegate(sdk.WrapSDKContext(ctx), &types.MsgBeginRedelegate{
+		DelegatorAddress:    delegatorAddress.String(),
+		ValidatorSrcAddress: validatorAAddress.String(),
+		ValidatorDstAddress: validatorBAddress.String(),
+		Amount:              redelegateCoin,
+	})
+	require.NoError(t, err, "no error expected during redelegation")
+
+	checkValidatorBondShares(validatorAAddress, delegation1Amount.Add(delegation2Amount).Sub(redelegateAmount))
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+
+	// Undelegate from validator A - it should have removed the shares
+	_, err = msgServer.Undelegate(sdk.WrapSDKContext(ctx), &types.MsgUndelegate{
+		DelegatorAddress: delegatorAddress.String(),
+		ValidatorAddress: validatorAAddress.String(),
+		Amount:           undelegateCoin,
+	})
+	require.NoError(t, err, "no error expected during undelegation")
+
+	expectedBondShares := delegation1Amount.Add(delegation2Amount).Sub(redelegateAmount).Sub(undelegateAmount)
+	checkValidatorBondShares(validatorAAddress, expectedBondShares)
+	checkValidatorBondShares(validatorBAddress, sdk.ZeroInt())
+}

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -138,29 +138,29 @@ func (k Keeper) DecreaseTotalLiquidStakedTokens(ctx sdk.Context, amount sdk.Int)
 // and the total liquid staked shares cannot exceed the validator bond cap
 // 1) (TotalLiquidStakedTokens / TotalStakedTokens) <= ValidatorLiquidStakingCap
 // 2) LiquidShares <= (ValidatorBondShares * ValidatorBondFactor)
-func (k Keeper) SafelyIncreaseValidatorLiquidShares(ctx sdk.Context, validator *types.Validator, shares sdk.Dec) error {
+func (k Keeper) SafelyIncreaseValidatorLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error {
 	// Confirm the validator bond factor and validator liquid staking cap will not be exceeded
-	if k.CheckExceedsValidatorBondCap(ctx, *validator, shares) {
+	if k.CheckExceedsValidatorBondCap(ctx, validator, shares) {
 		return types.ErrInsufficientValidatorBondShares
 	}
-	if k.CheckExceedsValidatorLiquidStakingCap(ctx, *validator, shares) {
+	if k.CheckExceedsValidatorLiquidStakingCap(ctx, validator, shares) {
 		return types.ErrValidatorLiquidStakingCapExceeded
 	}
 
 	// Increment the validator's liquid shares
 	validator.LiquidShares = validator.LiquidShares.Add(shares)
-	k.SetValidator(ctx, *validator)
+	k.SetValidator(ctx, validator)
 
 	return nil
 }
 
 // DecreaseValidatorLiquidShares decrements the liquid shares on a validator
-func (k Keeper) DecreaseValidatorLiquidShares(ctx sdk.Context, validator *types.Validator, shares sdk.Dec) error {
+func (k Keeper) DecreaseValidatorLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error {
 	if shares.GT(validator.LiquidShares) {
 		return types.ErrValidatorLiquidSharesUnderflow
 	}
 	validator.LiquidShares = validator.LiquidShares.Sub(shares)
-	k.SetValidator(ctx, *validator)
+	k.SetValidator(ctx, validator)
 	return nil
 }
 
@@ -174,7 +174,7 @@ func (k Keeper) IncreaseValidatorBondShares(ctx sdk.Context, validator types.Val
 // SafelyDecreaseValidatorBond decrements the validator's self bond
 // so long as it will not cause the current delegations to exceed the threshold
 // set by validator bond factor
-func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, validator *types.Validator, shares sdk.Dec) error {
+func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error {
 	// Check if the decreased self bond will cause the validator bond threshold to be exceeded
 	validatorBondFactor := k.ValidatorBondFactor(ctx)
 	validatorBondEnabled := !validatorBondFactor.Equal(types.ValidatorBondCapDisabled)
@@ -186,7 +186,7 @@ func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, validator *types.Va
 
 	// Decrement the validator's total self bond
 	validator.ValidatorBondShares = validator.ValidatorBondShares.Sub(shares)
-	k.SetValidator(ctx, *validator)
+	k.SetValidator(ctx, validator)
 
 	return nil
 }
@@ -335,16 +335,21 @@ func (k Keeper) RemoveExpiredTokenizeShareLocks(ctx sdk.Context, blockTime time.
 	iterator := store.Iterator(types.TokenizeSharesUnlockQueuePrefix, prefixEnd)
 	defer iterator.Close()
 
+	// collect all unlocked addresses
 	unlockedAddresses = []string{}
 	for ; iterator.Valid(); iterator.Next() {
 		authorizations := types.PendingTokenizeShareAuthorizations{}
 		k.cdc.MustUnmarshal(iterator.Value(), &authorizations)
 
 		for _, addressString := range authorizations.Addresses {
-			k.RemoveTokenizeSharesLock(ctx, sdk.MustAccAddressFromBech32(addressString))
 			unlockedAddresses = append(unlockedAddresses, addressString)
 		}
 		store.Delete(iterator.Key())
+	}
+
+	// remove the lock from each unlocked address
+	for _, unlockedAddress := range unlockedAddresses {
+		k.RemoveTokenizeSharesLock(ctx, sdk.MustAccAddressFromBech32(unlockedAddress))
 	}
 
 	return unlockedAddresses

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -164,6 +164,13 @@ func (k Keeper) DecreaseValidatorLiquidShares(ctx sdk.Context, validator *types.
 	return nil
 }
 
+// Increase validator bond shares increments the validator's self bond
+// in the event that the delegation amount on a validator bond delegation is increased
+func (k Keeper) IncreaseValidatorBondShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) {
+	validator.ValidatorBondShares = validator.ValidatorBondShares.Add(shares)
+	k.SetValidator(ctx, validator)
+}
+
 // SafelyDecreaseValidatorBond decrements the validator's self bond
 // so long as it will not cause the current delegations to exceed the threshold
 // set by validator bond factor

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -226,8 +226,14 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, tokens, false); err != nil {
 			return nil, err
 		}
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, &validator, shares); err != nil {
+		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
 			return nil, err
+		}
+		// Note: this is required for downstream uses of the validator variable
+		// since the validator's liquid shares were updated above
+		validator, found = k.GetValidator(ctx, valAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -296,7 +302,7 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 		return nil, err
 	}
 
-	delegation, found := k.GetDelegation(ctx, delegatorAddress, valSrcAddr)
+	srcDelegation, found := k.GetDelegation(ctx, delegatorAddress, valSrcAddr)
 	if !found {
 		return nil, status.Errorf(
 			codes.NotFound,
@@ -312,9 +318,16 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 
 	// If this is a validator self-bond, the new liquid delegation cannot fall below the self-bond * bond factor
 	// The delegation on the new validator will not a validator bond
-	if delegation.ValidatorBond {
-		if err := k.SafelyDecreaseValidatorBond(ctx, &srcValidator, srcShares); err != nil {
+	if srcDelegation.ValidatorBond {
+		if err := k.SafelyDecreaseValidatorBond(ctx, srcValidator, srcShares); err != nil {
 			return nil, err
+		}
+
+		// Note: this is required for downstream uses of the srcValidator variable
+		// since the validator bond shares were updated above
+		srcValidator, found = k.GetValidator(ctx, valSrcAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -327,11 +340,18 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 			return nil, err
 		}
 
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, &dstValidator, dstShares); err != nil {
+		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, dstValidator, dstShares); err != nil {
 			return nil, err
 		}
-		if err := k.DecreaseValidatorLiquidShares(ctx, &srcValidator, srcShares); err != nil {
+		if err := k.DecreaseValidatorLiquidShares(ctx, srcValidator, srcShares); err != nil {
 			return nil, err
+		}
+
+		// Note: this is required for downstream uses of each validator variable
+		// since the liquid shares were updated above
+		srcValidator, found = k.GetValidator(ctx, valSrcAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -347,6 +367,19 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// If the redelegation adds to a validator bond delegation, update the validator's bond shares
+	dstDelegation, found := k.GetDelegation(ctx, delegatorAddress, valDstAddr)
+	if !found {
+		return nil, types.ErrNoDelegation
+	}
+	if dstDelegation.ValidatorBond {
+		dstShares, err := dstValidator.SharesFromTokensTruncated(msg.Amount.Amount)
+		if err != nil {
+			return nil, err
+		}
+		k.IncreaseValidatorBondShares(ctx, dstValidator, dstShares)
 	}
 
 	if msg.Amount.Amount.IsInt64() {
@@ -412,8 +445,15 @@ func (k msgServer) Undelegate(goCtx context.Context, msg *types.MsgUndelegate) (
 
 	// if this is a validator self-bond, the new liquid delegation cannot fall below the self-bond * bond factor
 	if delegation.ValidatorBond {
-		if err := k.SafelyDecreaseValidatorBond(ctx, &validator, shares); err != nil {
+		if err := k.SafelyDecreaseValidatorBond(ctx, validator, shares); err != nil {
 			return nil, err
+		}
+
+		// Note: this is required for downstream uses of the validator variable
+		// since the validator bond shares was updated above
+		validator, found = k.GetValidator(ctx, addr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -423,8 +463,15 @@ func (k msgServer) Undelegate(goCtx context.Context, msg *types.MsgUndelegate) (
 		if err := k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return nil, err
 		}
-		if err := k.DecreaseValidatorLiquidShares(ctx, &validator, shares); err != nil {
+		if err := k.DecreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
 			return nil, err
+		}
+
+		// Note: this is required for downstream uses of the validator variable
+		// since the liquid shares were updated above
+		validator, found = k.GetValidator(ctx, addr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -528,8 +575,15 @@ func (k msgServer) CancelUnbondingDelegation(goCtx context.Context, msg *types.M
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, tokens, false); err != nil {
 			return nil, err
 		}
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, &validator, shares); err != nil {
+		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
 			return nil, err
+		}
+
+		// Note: this is required for downstream uses of the validator variable
+		// since the validator's liquid shares were updated above
+		validator, found = k.GetValidator(ctx, valAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -558,9 +612,18 @@ func (k msgServer) CancelUnbondingDelegation(goCtx context.Context, msg *types.M
 	}
 
 	// delegate back the unbonding delegation amount to the validator
-	_, err = k.Keeper.Delegate(ctx, delegatorAddress, msg.Amount.Amount, types.Unbonding, validator, false)
+	newShares, err := k.Keeper.Delegate(ctx, delegatorAddress, msg.Amount.Amount, types.Unbonding, validator, false)
 	if err != nil {
 		return nil, err
+	}
+
+	// If the delegation is a validator bond, increment the validator bond shares
+	delegation, found := k.Keeper.GetDelegation(ctx, delegatorAddress, valAddr)
+	if !found {
+		return nil, types.ErrNoDelegation
+	}
+	if delegation.ValidatorBond {
+		k.IncreaseValidatorBondShares(ctx, validator, newShares)
 	}
 
 	amount := unbondEntry.Balance.Sub(msg.Amount.Amount)
@@ -699,8 +762,15 @@ func (k msgServer) TokenizeShares(goCtx context.Context, msg *types.MsgTokenizeS
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, msg.Amount.Amount, true); err != nil {
 			return nil, err
 		}
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, &validator, shares); err != nil {
+		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
 			return nil, err
+		}
+
+		// Note: this is required for downstream uses of the validator variable
+		// since the validator's liquid shares were updated above
+		validator, found = k.GetValidator(ctx, valAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -841,8 +911,15 @@ func (k msgServer) RedeemTokensForShares(goCtx context.Context, msg *types.MsgRe
 		if err := k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return nil, err
 		}
-		if err := k.DecreaseValidatorLiquidShares(ctx, &validator, shares); err != nil {
+		if err := k.DecreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
 			return nil, err
+		}
+
+		// Note: this is required for downstream uses of the validator variable
+		// since the liquid shares were updated above
+		validator, found = k.GetValidator(ctx, valAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
 		}
 	}
 


### PR DESCRIPTION
New logic from upstream that ensures increased validator bond shares during delegation.

This allows to increase delegation after marking previous delegation as bond, thus allowing to LSM-tokenize more.

Test is in this PR:
https://github.com/persistenceOne/persistenceCore/pull/225

Upstream changes:
https://github.com/iqlusioninc/cosmos-sdk/pull/24
